### PR TITLE
Create uploads directory when installing level 2

### DIFF
--- a/levels/2/ctf-install.sh
+++ b/levels/2/ctf-install.sh
@@ -14,4 +14,5 @@ fi
 DIR="$( cd "$( dirname "$0" )" && pwd)"
 PASSWORD="${1}"
 
+mkdir "${DIR}/uploads"
 echo "${PASSWORD}" > "${DIR}/password.txt"


### PR DESCRIPTION
The level 2 server puts uploaded files in an `uploads` directory, but it's not getting created when the level is installed.